### PR TITLE
fixed broken and outdated doc links

### DIFF
--- a/src/pages/api/architecture/exception_handling.md
+++ b/src/pages/api/architecture/exception_handling.md
@@ -26,7 +26,7 @@ to handle exceptions for the second case.
 ## Prerequisites 
 
 To complete this tutorial, we need:
-- MXNet [7b24137](https://github.com/apache/incubator-mxnet/commit/7b24137ed45df605defa4ce72ec91554f6e445f0). See Instructions in [Setup and Installation](http://mxnet.io/install/index.html).
+- MXNet [7b24137](https://github.com/apache/incubator-mxnet/commit/7b24137ed45df605defa4ce72ec91554f6e445f0). See Instructions in [Setup and Installation]({{'/get_started'|relative_url}}).
 
 ## Exception Handling for Iterators
 

--- a/src/pages/api/architecture/note_engine.md
+++ b/src/pages/api/architecture/note_engine.md
@@ -365,11 +365,11 @@ Allowing mutation mitigates these issues.
 ## Source Code of the Generic Dependency Engine
 [MXNet](https://github.com/dmlc/mxnet) provides an implementation
 of the generic dependency engine described in this page.
-You can find more details in [this topic](http://mxnet.io/architecture/note_engine.html).
+You can find more details in [this topic](note_engine).
 We welcome your contributions.
 
 ## Next Steps
 
-* [Squeeze the Memory Consumption of Deep Learning](http://mxnet.io/architecture/note_memory.html)
-* [Efficient Data Loading Module for Deep Learning](http://mxnet.io/architecture/note_data_loading.html)
+* [Squeeze the Memory Consumption of Deep Learning](note_memory)
+* [Efficient Data Loading Module for Deep Learning](note_data_loading)
 * [Survey of RNN Interface](http://mxnet.io/architecture/rnn_interface.html)

--- a/src/pages/api/architecture/note_memory.md
+++ b/src/pages/api/architecture/note_memory.md
@@ -331,5 +331,5 @@ So here are two takeaways:
 
 ## Next Steps
 
-* [Efficient Data Loading Module for Deep Learning](http://mxnet.io/architecture/note_data_loading.html)
+* [Efficient Data Loading Module for Deep Learning](note_data_loading)
 * [Survey of RNN Interface](http://mxnet.io/architecture/rnn_interface.html)

--- a/src/pages/api/architecture/overview.md
+++ b/src/pages/api/architecture/overview.md
@@ -41,7 +41,7 @@ execute a bunch of functions following their dependencies.
 Execution of any two functions with dependencies should be serialized.
 To boost performance, functions with no dependencies *can* be executed in parallel.
 For a general discussion of this topic,
-see our [notes on the dependency engine](note_engine.md).
+see our [notes on the dependency engine](note_engine).
 
 ### Interface
 

--- a/src/pages/api/architecture/program_model.md
+++ b/src/pages/api/architecture/program_model.md
@@ -601,13 +601,13 @@ to create more interesting and intelligent deep learning libraries.
 
 ## Contribute to MXNet
 
-This document is part of our effort to provide [open-source system design notes](index.md)
+This document is part of our effort to provide [open-source system design notes](overview)
 for deep learning libraries. If you're interested in contributing to _MXNet_ or its
 documentation, [fork us on GitHub](http://github.com/dmlc/mxnet).
 
 ## Next Steps
 
-* [Dependency Engine for Deep Learning](http://mxnet.io/architecture/note_engine.html)
-* [Squeeze the Memory Consumption of Deep Learning](http://mxnet.io/architecture/note_memory.html)
-* [Efficient Data Loading Module for Deep Learning](http://mxnet.io/architecture/note_data_loading.html)
+* [Dependency Engine for Deep Learning](note_engine)
+* [Squeeze the Memory Consumption of Deep Learning](note_memory)
+* [Efficient Data Loading Module for Deep Learning](note_data_loading)
 * [Survey of RNN Interface](http://mxnet.io/architecture/rnn_interface.html)

--- a/src/pages/api/clojure/docs/tutorials/kvstore.md
+++ b/src/pages/api/clojure/docs/tutorials/kvstore.md
@@ -11,7 +11,7 @@ Topics:
 
 * [Basic Push and Pull](#basic-push-and-pull)
 * [List Key-Value Pairs](#list-key-value-pairs)
-* [API Reference](http://mxnet.incubator.apache.org/api/clojure/docs/org.apache.clojure-mxnet.kvstore.html)
+* [Clojure API Reference]({{'/api/clojure/docs/api'|relative_url}})
 
 To follow along with this documentation, you can use this namespace to with the needed requires:
 

--- a/src/pages/api/clojure/docs/tutorials/module.md
+++ b/src/pages/api/clojure/docs/tutorials/module.md
@@ -13,11 +13,10 @@ The module API provides an intermediate and high-level interface for performing 
 Topics:
 
 * [Prepare the Data](#prepare-the-data)
-* [List Key-Value Pairs](#list-key-value-pairs)
 * [Preparing a Module for Computation](#preparing-a-module-for-computation)
 * [Training and Predicting](#training-and-predicting)
 * [Saving and Loading](#saving-and-loading)
-* [API Reference](http://mxnet.incubator.apache.org/api/clojure/docs/org.apache.clojure-mxnet.module.html)
+* [Clojure API Reference]({{'/api/clojure/docs/api'|relative_url}})
 
 
 To follow along with this documentation, you can use this namespace to with the needed requires:
@@ -130,9 +129,9 @@ You can pass in batch-end callbacks using batch-end-callback and epoch-end callb
 (first (ndarray/->vec (first results))) ;=>0.08261358
 ```
 
-The module collects and returns all of the prediction results. For more details about the format of the return values, see the documentation for the [`predict`](docs/org.apache.clojure-mxnet.module.html#var-fit-params) function.
+The module collects and returns all of the prediction results. For more details about the format of the return values, see the documentation for the [`predict`]({{'/api/clojure/docs/api/org.apache.clojure-mxnet.module.html#var-predict'|relative_url}}) function.
 
-When prediction results might be too large to fit in memory, use the [`predict-every-batch`](docs/org.apache.clojure-mxnet.module.html#predict-every-batch) API.
+When prediction results might be too large to fit in memory, use the [`predict-every-batch`]({{'/api/clojure/docs/api/org.apache.clojure-mxnet.module.html#var-predict-every-batch'|relative_url}}) API.
 
 ```clojure
 (let [preds (m/predict-every-batch mod {:eval-data test-data})]
@@ -238,6 +237,6 @@ Create fit-params and then use it to set `begin-epoch` so that `fit` knows to re
 
 
 ## Next Steps
-* See [Symbolic API](symbol.md) for operations on NDArrays that assemble neural networks from layers.
-* See [NDArray API](ndarray.md) for vector/matrix/tensor operations.
-* See [KVStore API](kvstore.md) for multi-GPU and multi-host distributed training.
+* See [Symbolic API](symbol) for operations on NDArrays that assemble neural networks from layers.
+* See [NDArray API](ndarray) for vector/matrix/tensor operations.
+* See [KVStore API](kvstore) for multi-GPU and multi-host distributed training.

--- a/src/pages/api/clojure/docs/tutorials/ndarray.md
+++ b/src/pages/api/clojure/docs/tutorials/ndarray.md
@@ -15,7 +15,7 @@ Topics:
 
 * [Create NDArray](#create-ndarray)
 * [NDArray Operations](#ndarray-operations)
-* [NDArray API Reference](http://mxnet.incubator.apache.org/api/clojure/docs/org.apache.clojure-mxnet.ndarray.html)
+* [NDArray API Reference]({{'/api/clojure/docs/api/org.apache.clojure-mxnet.ndarray-api.html'|relative_url}})
 
 To follow along with this documentation, you can use this namespace with the needed requires:
 
@@ -124,4 +124,4 @@ Device information is stored in the `mxnet.Context` structure. When creating NDA
 ```
 
 ## Next Steps
-* See [KVStore API](kvstore.md) for multi-GPU and multi-host distributed training.
+* See [KVStore API](kvstore) for multi-GPU and multi-host distributed training.

--- a/src/pages/api/clojure/docs/tutorials/symbol.md
+++ b/src/pages/api/clojure/docs/tutorials/symbol.md
@@ -15,10 +15,10 @@ Topics:
 * [Group Multiple Symbols](#group-multiple-symbols)
 * [Serialization](#serialization)
 * [Executing Symbols](#executing-symbols)
-* [Symbol API Reference](http://mxnet.incubator.apache.org/api/clojure/docs/org.apache.clojure-mxnet.symbol.html)
+* [Symbol API Reference]({{'/api/clojure/docs/api/org.apache.clojure-mxnet.symbol'|relative_url}})
 
 
-We also highly encourage you to read [Symbolic Configuration and Execution in Pictures](symbol_in_pictures.md).
+We also highly encourage you to read [Symbolic Configuration and Execution in Pictures](symbol_in_pictures).
 
 To follow along with this documentation, you can use this namespace to with the following requirements:
 
@@ -95,7 +95,7 @@ To construct neural networks with multiple loss layers, we can use `group` to gr
 ```
 
 ## Serialization
-You can use the [`save`](docs/org.apache.clojure-mxnet.symbol.html#var-save) and [`load`](docs/org.apache.clojure-mxnet.symbol.html#var-load) functions to serialize the Symbol objects. The advantage of using save and load functions is that it is language agnostic and cloud friendly. The symbol is saved in JSON format. You can also get a JSON string directly using mxnet.Symbol.toJson. Refer to API documentation for more details.
+You can use the [`save`]({{'/api/clojure/docs/api/org.apache.clojure-mxnet.symbol.html#var-save'|relative_url}}) and [`load`]({{'/api/clojure/docs/api/org.apache.clojure-mxnet.symbol.html#var-load'|relative_url}}) functions to serialize the Symbol objects. The advantage of using save and load functions is that it is language agnostic and cloud friendly. The symbol is saved in JSON format. You can also get a JSON string directly using mxnet.Symbol.toJson. Refer to API documentation for more details.
 
  The following example shows how to save a symbol to a file, load it back, and compare two symbols using a JSON string. You can also save to S3 as well
 
@@ -136,5 +136,5 @@ _To do this you must have the correct native library jar defined as a dependency
 ```
 
 ## Next Steps
-* See [NDArray API](ndarray.md) for vector/matrix/tensor operations.
-* See [KVStore API](kvstore.md) for multi-GPU and multi-host distributed training.
+* See [NDArray API](ndarray) for vector/matrix/tensor operations.
+* See [KVStore API](kvstore) for multi-GPU and multi-host distributed training.

--- a/src/pages/api/clojure/docs/tutorials/symbol_in_pictures.md
+++ b/src/pages/api/clojure/docs/tutorials/symbol_in_pictures.md
@@ -10,7 +10,7 @@ permalink: /api/clojure/docs/tutorials/symbol_in_pictures
 
 This topic explains symbolic construction and execution in pictures.
 
-We recommend that you read the [Symbolic API](symbol.md) as another useful reference.
+We recommend that you read the [Symbolic API](symbol) as another useful reference.
 
 ## Compose Symbols
 
@@ -82,4 +82,4 @@ Auxiliary states are just like arguments, except that you can't take the gradien
 
 ## Next Steps
 
-See [Symbolic API](symbol.md) and [Python Documentation](index.md).
+See [Symbolic API](symbol) and [Python Documentation]({{'/api/python'|relative_url}}).

--- a/src/pages/api/cpp/docs/tutorials/basics.md
+++ b/src/pages/api/cpp/docs/tutorials/basics.md
@@ -25,7 +25,7 @@ and decompress them into `data/mnist_data` folder.
 Except linking the MXNet shared library, the C++ package itself is a header-only package,
 which means all you need to do is to include the header files. Among the header files,
 `op.h` is special since it is generated dynamically. The generation should be done when
-[building the C++ package](http://mxnet.incubator.apache.org/versions/master/api/c++/index.html).
+[building the C++ package]({{'/api/cpp/'|relative_url}}).
 It is important to note that you need to **copy the shared library** (`libmxnet.so` in Linux and MacOS,
 `libmxnet.dll` in Windows) from `/path/to/mxnet/lib` to the working directory.
 We do not recommend you to use pre-built binaries because MXNet is under heavy development,

--- a/src/pages/api/cpp/docs/tutorials/mxnet_cpp_inference_tutorial.md
+++ b/src/pages/api/cpp/docs/tutorials/mxnet_cpp_inference_tutorial.md
@@ -12,19 +12,19 @@ tag: cpp
 
 ## Overview
 MXNet provides various useful tools and interfaces for deploying your model for inference. For example, you can use [MXNet Model Server](https://github.com/awslabs/mxnet-model-server) to start a service and host your trained model easily.
-Besides that, you can also use MXNet's different language APIs to integrate your model with your existing service. We provide [Python](https://mxnet.incubator.apache.org/api/python/module/module.html),    [Java](https://mxnet.incubator.apache.org/api/java/index.html), [Scala](https://mxnet.incubator.apache.org/api/scala/index.html), and [C++](https://mxnet.incubator.apache.org/api/c++/index.html) APIs.
+Besides that, you can also use MXNet's different language APIs to integrate your model with your existing service. We provide [Python]({{'/api/python/docs/api/symbol-related/mxnet.module'|relative_url}}),    [Java]({{'/api/java/docs/api'|relative_url}}), [Scala]({{'/api/scala/docs/api'|relative_url}}), and [C++]({{'/api/cpp/docs/api'|relative_url}}) APIs.
 
-This tutorial is a continuation of the [Gluon end to end tutorial](https://mxnet.apache.org/versions/master/tutorials/gluon/gluon_from_experiment_to_deployment.html), we will focus on the MXNet C++ API. We have slightly modified the code in [C++ Inference Example](https://github.com/apache/incubator-mxnet/tree/master/cpp-package/example/inference) for our use case.
+This tutorial is a continuation of the [Gluon end to end tutorial](https://mxnet.apache.org/versions/master/tutorials/gluon/gluon_from_experiment_to_deployment.html), we will focus on the MXNet C++ API. We have slightly modified the code in [C++ Inference Example](https://github.com/apache/incubator-mxnet/tree/ma/example/inference) for our use case.
 
 ## Prerequisites
 
 To complete this tutorial, you need:
 - Complete the training part of [Gluon end to end tutorial](https://mxnet.apache.org/versions/master/tutorials/gluon/gluon_from_experiment_to_deployment.html)
-- Learn the basics about [MXNet C++ API](https://github.com/apache/incubator-mxnet/tree/master/cpp-package)
+- Learn the basics about [MXNet C++ API]({{'/api/cpp'|relative_url}})
 
 
 ## Setup the MXNet C++ API
-To use the C++ API in MXNet, you need to build MXNet from source with C++ package. Please follow the [built from source guide](https://mxnet.incubator.apache.org/install/ubuntu_setup.html), and [C++ Package documentation](https://github.com/apache/incubator-mxnet/tree/master/cpp-package)
+To use the C++ API in MXNet, you need to build MXNet from source with C++ package. Please follow the [built from source guide]({{'/get_started/ubuntu_setup.html'|relative_url}}), and [C++ Package documentation]({{'/api/cpp'|relative_url}})
 to enable the C++ API.
 The summary of those two documents is that you need to build MXNet from source with `USE_CPP_PACKAGE` flag set to 1. For example: `make -j USE_CPP_PACKAGE=1`.
 
@@ -266,7 +266,7 @@ Then it will predict your image:
 
 Now you can explore more ways to run inference and deploy your models:
 1. [Java Inference examples](https://github.com/apache/incubator-mxnet/tree/master/scala-package/examples/src/main/java/org/apache/mxnetexamples/javaapi/infer)
-2. [Scala Inference examples](https://mxnet.incubator.apache.org/tutorials/scala/)
+2. [Scala Inference examples]({{'/api/scala/docs/tutorials/infer'|relative_url}})
 3. [ONNX model inference examples](https://mxnet.incubator.apache.org/tutorials/onnx/inference_on_onnx_model.html)
 4. [MXNet Model Server Examples](https://github.com/awslabs/mxnet-model-server/tree/master/examples)
 

--- a/src/pages/api/faq/add_op_in_backend.md
+++ b/src/pages/api/faq/add_op_in_backend.md
@@ -103,7 +103,7 @@ skip passing 0-value parameters through the quadratic operator interface. You
 can choose not to define the default value for a parameter if it is required
 at runtime. Meanwhile, adding brief descriptions to the parameters enables
 the documentation engine to display them on
-[MXNet documentation web page](https://mxnet.incubator.apache.org/api/python/index.html).
+[MXNet documentation web page]({{'/api/python/docs/api'|relative_url}}).
 
 ### Attribute Inference
 Attribute inference is the process of deducing the properties of `NDArray`s
@@ -357,7 +357,7 @@ with respect to the outputs of the last layer throughout the network to the firs
 layer. The whole process is often known as backward propagation. We are not
 going to delineate the principle of backward propagation here since users can find
 great details covered in other resources, such as
-[CS231n](http://cs231n.github.io/optimization-2/) and
+[CS231n](https://cs231n.github.io/optimization-2/) and
 [How the backgropagation algorithm works](http://neuralnetworksanddeeplearning.com/chap2.html).
 The problem we are going to solve here for the `quadratic` operator is that
 given a tensor representing the gradient of the loss function with respect
@@ -673,4 +673,4 @@ and
 [test_operator.py](https://github.com/apache/incubator-mxnet/blob/master/tests/python/unittest/test_operator.py#L6514).
 
 ## Additional Resources
-- [Use TensorInspector to Help Debug Operators](tensor_inspector_tutorial.md)
+- [Use TensorInspector to Help Debug Operators](tensor_inspector_tutorial)

--- a/src/pages/api/faq/caffe.md
+++ b/src/pages/api/faq/caffe.md
@@ -88,7 +88,7 @@ are the steps of how to rebuild Caffe:
    cd caffe && wget https://github.com/BVLC/caffe/pull/4527.patch && git apply 4527.patch
    ```
 3. Build and install Caffe by following the
-   [official guide](http://caffe.berkeleyvision.org/installation.html).
+   [official guide](https://caffe.berkeleyvision.org/installation.html).
 
 Next we need to compile MXNet with Caffe supports
 

--- a/src/pages/api/faq/cloud.md
+++ b/src/pages/api/faq/cloud.md
@@ -29,7 +29,7 @@ how to set up an AWS cluster with _MXNet_. We show how to:
 ### Use Amazon S3 to Host Data
 
 Amazon S3 provides distributed data storage which proves especially convenient for hosting large datasets.
-To use S3, you need [AWS credentials](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html),
+To use S3, you need [AWS credentials](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html),
 including an `ACCESS_KEY_ID` and a `SECRET_ACCESS_KEY`.
 
 To use _MXNet_ with S3, set the environment variables `AWS_ACCESS_KEY_ID` and
@@ -42,7 +42,7 @@ export AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
 ```
 
 There are several ways to upload data to S3. One simple way is to use
-[s3cmd](http://s3tools.org/s3cmd). For example:
+[s3cmd](https://s3tools.org/s3cmd). For example:
 
 ```bash
 wget http://data.mxnet.io/mxnet/data/mnist.zip
@@ -61,7 +61,7 @@ The AMI IDs are the following:
 * eu-west-1: ami-6e5d6808
 
 Now you can launch _MXNet_ directly on an EC2 GPU instance.  
-You can also use [Jupyter](http://jupyter.org) notebook on EC2 machine.
+You can also use [Jupyter](https://jupyter.org) notebook on EC2 machine.
 Here is a [good tutorial](https://github.com/dmlc/mxnet-notebooks)
 on how to connect to a Jupyter notebook running on an EC2 instance.
 

--- a/src/pages/api/faq/distributed_training.md
+++ b/src/pages/api/faq/distributed_training.md
@@ -21,7 +21,7 @@ In this document, we describe how to train a model with devices distributed acro
 
 When models are so large that they don't fit into device memory, then a second way called *model parallelism* is useful.
 Here, different devices are assigned the task of learning different parts of the model.
-Currently, MXNet supports Model parallelism in a single machine only. Refer [Training with multiple GPUs using model parallelism](https://mxnet.incubator.apache.org/versions/master/faq/model_parallel_lstm.html) for more on this.
+Currently, MXNet supports Model parallelism in a single machine only. Refer [Training with multiple GPUs using model parallelism](model_parallel_lstm) for more on this.
 
 ## How Does Distributed Training Work?
 The following concepts are key to understanding distributed training in MXNet:
@@ -53,7 +53,7 @@ The distributed mode of KVStore is enabled by calling `mxnet.kvstore.create` fun
 with a string argument which contains the word `dist` as follows:
 > kv = mxnet.kvstore.create('dist_sync')
 
-Refer [KVStore API](https://mxnet.incubator.apache.org/versions/master/api/python/kvstore/kvstore.html) for more information about KVStore.
+Refer [KVStore API]({{'/api/python/docs/api/gluon-related/mxnet.kvstore.KVStore.html#mxnet.kvstore.KVStore'|relative_url}}) for more information about KVStore.
 
 ### Distribution of Keys
 Each server doesn't necessarily store all the keys or parameter arrays.
@@ -75,7 +75,7 @@ In the case of distributed training though, we would need to divide the dataset 
 
 Typically, this split of data for each worker happens through the data iterator,
 on passing the number of parts and the index of parts to iterate over.
-Some iterators in MXNet that support this feature are [mxnet.io.MNISTIterator](https://mxnet.incubator.apache.org/versions/master/api/python/io/io.html#mxnet.io.MNISTIter) and [mxnet.io.ImageRecordIter](https://mxnet.incubator.apache.org/versions/master/api/python/io/io.html#mxnet.io.ImageRecordIter).
+Some iterators in MXNet that support this feature are [mxnet.io.MNISTIterator]({{'/api/python/docs/api/gluon-related/_autogen/mxnet.io.MNISTIter.html#mxnet.io.MNISTIter'|relative_url}}) and [mxnet.io.ImageRecordIter]({{'/api/python/docs/api/gluon-related/_autogen/mxnet.io.ImageRecordIter.html#mxnet.io.ImageRecordIter'|relative_url}}).
 If you are using a different iterator, you can look at how the above iterators implement this.
 We can use the kvstore object to get the number of workers (`kv.num_workers`) and rank of the current worker (`kv.rank`).
 These can be passed as arguments to the iterator.
@@ -85,7 +85,7 @@ to see an example usage.
 ### Updating weights
 KVStore server supports two modes, one which aggregates the gradients and updates the weights using those gradients, and second where the server only aggregates gradients. In the latter case, when a worker process pulls from kvstore, it gets the aggregated gradients. The worker then uses these gradients and applies the weights locally. 
 
-When using Gluon there is an option to choose between these modes by passing `update_on_kvstore` variable when you create the [Trainer](https://mxnet.incubator.apache.org/versions/master/api/python/gluon/gluon.html#mxnet.gluon.Trainer) object like this:
+When using Gluon there is an option to choose between these modes by passing `update_on_kvstore` variable when you create the [Trainer]({{'/api/python/docs/api/gluon/mxnet.gluon.Trainer.html'|relative_url}}) object like this:
 
 ```
 trainer = gluon.Trainer(net.collect_params(), optimizer='sgd',
@@ -126,7 +126,7 @@ This is faster than `dist_sync` because it reduces expensive communication betwe
 ### Gradient Compression
 When communication is expensive, and the ratio of computation time to communication time is low, communication can become a bottleneck.
 In such cases, gradient compression can be used to reduce the cost of communication, thereby speeding up training.
-Refer [Gradient compression](https://mxnet.incubator.apache.org/versions/master/faq/gradient_compression.html) for more details.
+Refer [Gradient compression]({{'/api/faq/gradient_compression'|relative_url}}) for more details.
 
 Note: For small models when the cost of computation is much lower than cost of communication,
 distributed training might actually be slower than training on a single machine because of the overhead of communication and synchronization.
@@ -163,7 +163,7 @@ The options in the following command are the recommended options when mounting a
 sudo mkdir efs && sudo mount -t nfs4 -o nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2 NETWORK_FILE_SYSTEM_IP:/ efs
 ```
 
-Tip: You might find it helpful to store large datasets on S3 for easy access from all machines in the cluster. Refer [Using data from S3 for training](https://mxnet.incubator.apache.org/versions/master/faq/s3_integration.html) for more information.
+Tip: You might find it helpful to store large datasets on S3 for easy access from all machines in the cluster. Refer [Using data from S3 for training]({{'/api/faq/s3_integration'|relative_url}}) for more information.
 
 ### Using Launch.py
 MXNet provides a script [tools/launch.py](https://github.com/apache/incubator-mxnet/blob/master/tools/launch.py) to make it easy to launch distributed training on a cluster with `ssh`, `mpi`, `sge` or `yarn`.

--- a/src/pages/api/faq/env_var.md
+++ b/src/pages/api/faq/env_var.md
@@ -45,7 +45,7 @@ $env:MXNET_STORAGE_FALLBACK_LOG_VERBOSE=0
   - The number of threads given to prioritized CPU jobs.
 * MXNET_CPU_NNPACK_NTHREADS
   - Values: Int ```(default=4)```
-  - The number of threads used for NNPACK. NNPACK package aims to provide high-performance implementations of some layers for multi-core CPUs. Checkout [NNPACK](http://mxnet.io/faq/nnpack.html) to know more about it.
+  - The number of threads used for NNPACK. NNPACK package aims to provide high-performance implementations of some layers for multi-core CPUs. Checkout [NNPACK]({{'/api/faq/nnpack'|relative_url}}) to know more about it.
 * MXNET_MP_WORKER_NTHREADS
   - Values: Int ```(default=1)```
   - The number of scheduling threads on CPU given to multiprocess workers. Enlarge this number allows more operators to run in parallel in individual workers but please consider reducing the overall `num_workers` to avoid thread contention (not available on Windows).
@@ -57,7 +57,7 @@ $env:MXNET_STORAGE_FALLBACK_LOG_VERBOSE=0
 
 * MXNET_EXEC_ENABLE_INPLACE
   - Values: true or false ```(default=true)```
-  - Whether to enable in-place optimization in symbolic execution. Checkout [in-place optimization](http://mxnet.io/architecture/note_memory.html#in-place-operations) to know more about it.
+  - Whether to enable in-place optimization in symbolic execution. Checkout [in-place optimization]({{'/api/architecture/note_memory#in-place-operations'|relative_url}}) to know more about it.
 * NNVM_EXEC_MATCH_RANGE
   - Values: Int ```(default=16)```
   - The approximate matching scale in the symbolic execution memory allocator.
@@ -67,7 +67,7 @@ $env:MXNET_STORAGE_FALLBACK_LOG_VERBOSE=0
   - Values: Int ```(default=1)```
   - The maximum number of temporary workspaces to allocate to each device. This controls space replicas and in turn reduces the memory usage.
   - Setting this to a small number can save GPU memory. It will also likely decrease the level of parallelism, which is usually acceptable.
-  - MXNet internally uses graph coloring algorithm to [optimize memory consumption](http://mxnet.io/architecture/note_memory.html).
+  - MXNet internally uses graph coloring algorithm to [optimize memory consumption]({{'/api/architecture/note_memory'|relative_url}}).
   - This parameter is also used to get number of matching colors in graph and in turn how much parallelism one can get in each GPU. Color based match usually costs more memory but also enables more parallelism.
 * MXNET_GPU_MEM_POOL_RESERVE
   - Values: Int ```(default=5)```

--- a/src/pages/api/faq/float16.md
+++ b/src/pages/api/faq/float16.md
@@ -4,7 +4,7 @@ title:  Float16
 category: faq
 faq_c: Speed
 question: How do I use mixed precision (float16) with MXNet or Gluon? 
-permalink: /api/faq/floa16
+permalink: /api/faq/float16
 ---
 
 # Mixed precision training using float16
@@ -31,19 +31,19 @@ This tutorial also assumes understanding of how to train a network with float32 
 
 With Gluon API, you need to take care of three things to convert a model to support computation with float16.
 
-1. Cast Gluon `Block`'s parameters and expected input type to float16 by calling the [cast](https://mxnet.incubator.apache.org/api/python/gluon/gluon.html#mxnet.gluon.Block.cast) method of the `Block` representing the network.
+1. Cast Gluon `Block`'s parameters and expected input type to float16 by calling the [cast]({{'/api/python/docs/api/gluon/mxnet.gluon.nn.Block.html#mxnet.gluon.nn.Block.cast'|relative_url}}) method of the `Block` representing the network.
 
 ```python
 net.cast('float16')
 ```
 
-2. Ensure the data input to the network is of float16 type. If your `DataLoader` or `Iterator` produces output in another datatype, then you would have to cast your data. There are different ways you can do this. The easiest would be to use the [astype](https://mxnet.incubator.apache.org/api/python/ndarray/ndarray.html#mxnet.ndarray.NDArray.astype) method of NDArrays.
+2. Ensure the data input to the network is of float16 type. If your `DataLoader` or `Iterator` produces output in another datatype, then you would have to cast your data. There are different ways you can do this. The easiest would be to use the [astype]({{'/api/python/docs/api/ndarray/_autogen/mxnet.ndarray.NDArray.astype.html#mxnet.ndarray.NDArray.astype'|relative_url}}) method of NDArrays.
 
 ```python
 data = data.astype('float16', copy=False)
 ```
 
-If you are using images and DataLoader, you can also use a [Cast transform](https://mxnet.incubator.apache.org/api/python/gluon/data.html#mxnet.gluon.data.vision.transforms.Cast).
+If you are using images and DataLoader, you can also use a [Cast transform]({{'/api/python/docs/api/gluon/_autogen/mxnet.gluon.data.vision.transforms.Cast.html#mxnet.gluon.data.vision.transforms.Cast'|relative_url}}).
 
 3. It is preferable to use **multi_precision mode of optimizer** when training in float16. This mode of optimizer maintains a master copy of the weights in float32 even when the training (i.e. forward and backward pass) is in float16. This helps increase precision of the weight updates and can lead to faster convergence in some scenarios.
 
@@ -82,7 +82,7 @@ net.features = pretrained_net.features
 net.cast('float16')
 ```
 
-You can check the parameters of the model by calling [summary](https://mxnet.incubator.apache.org/api/python/gluon/gluon.html#mxnet.gluon.Block.summary) with some fake data. Notice the provided `dtype=np.float16` in the line below. As it was mentioned earlier, we have to provide data as float16 as well.
+You can check the parameters of the model by calling [summary]({{'/api/python/docs/api/gluon/mxnet.gluon.nn.Block.html#mxnet.gluon.nn.Block.summary'|relative_url}}) with some fake data. Notice the provided `dtype=np.float16` in the line below. As it was mentioned earlier, we have to provide data as float16 as well.
 
 ```python
 net.summary(mx.nd.uniform(shape=(1, 3, 224, 224), dtype=np.float16))

--- a/src/pages/api/faq/model_parallel_lstm.md
+++ b/src/pages/api/faq/model_parallel_lstm.md
@@ -21,7 +21,7 @@ One key strength of _MXNet_ is its ability to leverage
 powerful heterogeneous hardware environments to achieve significant speedups.
 
 There are two primary ways that we can spread a workload across multiple devices.
-In a previous document, [we addressed data parallelism](./multi_devices.md),
+In a previous document, [we addressed data parallelism](multi_devices.md),
 an approach in which samples within a batch are divided among the available devices.
 With data parallelism, each device stores a complete copy of the model.
 Here, we explore _model parallelism_, a different approach.
@@ -34,7 +34,7 @@ LSTMS are powerful sequence models, that have proven especially useful
 for [natural language translation](https://arxiv.org/pdf/1409.0473.pdf), [speech recognition](https://arxiv.org/abs/1512.02595),
 and working with [time series data](https://arxiv.org/abs/1511.03677).
 For a general high-level introduction to LSTMs,
-see the excellent [tutorial](http://colah.github.io/posts/2015-08-Understanding-LSTMs/) by Christopher Olah.
+see the excellent [tutorial](https://colah.github.io/posts/2015-08-Understanding-LSTMs/) by Christopher Olah.
 
 
 ## Model Parallelism: Using Multiple GPUs As a Pipeline

--- a/src/pages/api/faq/new_op.md
+++ b/src/pages/api/faq/new_op.md
@@ -380,5 +380,5 @@ NNVM_REGISTER_OP(_backward_abs)
 ### Legacy Operators
 
 For the legacy (pre 0.9) way of defining operators with C++, please see:
-- [Developer Guide - Operators](http://mxnet.io/architecture/overview.html#operators-in-mxnet)
-- [Developer Guide - SimpleOp](http://mxnet.io/architecture/overview.html#simpleop-the-unified-operator-api)
+- [Developer Guide - Operators]({{'/api/architecture/overview.html#operators-in-mxnet'|relative_url}})
+- [Developer Guide - SimpleOp]({{'/api/architecture/overview.html#simpleop-the-unified-operator-api'|relative_url}})

--- a/src/pages/api/faq/nnpack.md
+++ b/src/pages/api/faq/nnpack.md
@@ -77,7 +77,7 @@ $ cd ~
 * Set lib path of NNPACK as the environment variable, e.g. `export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$YOUR_NNPACK_INSTALL_PATH/lib`
 * Add the include file of NNPACK and its third-party to  `ADD_CFLAGS` in config.mk, e.g. `ADD_CFLAGS = -I$(YOUR_NNPACK_INSTALL_PATH)/include/ -I$(YOUR_NNPACK_INSTALL_PATH)/third-party/pthreadpool/include/`
 * Set `USE_NNPACK = 1` in config.mk.
-* Build MXNet from source following the [install guide](http://mxnet.io/install/index.html).
+* Build MXNet from source following the [install guide]({{'/get_started'|relative_url}}).
 
 ### NNPACK Performance
 

--- a/src/pages/api/faq/perf.md
+++ b/src/pages/api/faq/perf.md
@@ -118,7 +118,7 @@ AWS EC2 C5.xlarge:
 
 ## Other CPU
 
-If using CPUs (not just Intel CPUs -- ARMs also), NNPACK can improve the running performance with 2x~7x, please check [nnpack.md](./nnpack.md) for details.
+If using CPUs (not just Intel CPUs -- ARMs also), NNPACK can improve the running performance with 2x~7x, please check [nnpack](nnpack) for details.
 
 ## Nvidia GPU
 
@@ -273,7 +273,7 @@ that gives detailed information about execution time at the symbol level.
 This feature complements general profiling tools like _nvprof_ and _gprof_
 by summarizing at the operator level, instead of a function, kernel, or instruction level.
 
-The profiler can be turned on with an [environment variable](http://mxnet.io/faq/env_var.html#control-the-profiler)
+The profiler can be turned on with an [environment variable]({{'/api/faq/env_var#control-the-profiler/"\relative_url}})
 for an entire program run, or programmatically for just part of a run.
 See [example/profiler](https://github.com/dmlc/mxnet/tree/master/example/profiler)
 for complete examples of how to use the profiler in code, but briefly, the Python code looks like:

--- a/src/pages/api/faq/s3_integration.md
+++ b/src/pages/api/faq/s3_integration.md
@@ -25,7 +25,7 @@ Following are detailed instructions on how to use data from S3 for training.
 
 ## Step 1: Build MXNet with S3 integration enabled
 
-Follow instructions [here](http://mxnet.io/install/index.html) to install MXNet from source with the following additional steps to enable S3 integration.
+Follow instructions [here]({{'/get_started'|relative_url}}) to install MXNet from source with the following additional steps to enable S3 integration.
 
 1. Install `libcurl4-openssl-dev` and `libssl-dev` before building MXNet. These packages are required to read/write from AWS S3.
 2. Append `USE_S3=1` to `config.mk` before building MXNet.

--- a/src/pages/api/faq/visualize_graph.md
+++ b/src/pages/api/faq/visualize_graph.md
@@ -18,13 +18,13 @@ from which the result can be read.
 
 ## Prerequisites
 You need the [Jupyter Notebook](http://jupyter.readthedocs.io/en/latest/)
-and [Graphviz](http://www.graphviz.org/) libraries to visualize the network.
-Please make sure you have followed [installation instructions](http://mxnet.io/install/index.html)
+and [Graphviz](https://www.graphviz.org/) libraries to visualize the network.
+Please make sure you have followed [installation instructions]({{'get_started'|relative_url}})
 in setting up above dependencies along with setting up MXNet.
 
 ## Visualize the sample Neural Network
 
-```mx.viz.plot_network``` takes [Symbol](http://mxnet.io/api/python/symbol/symbol.html), with your Network definition, and optional node_attrs, parameters for the shape of the node in the graph,  as input and generates a computation graph.
+```mx.viz.plot_network``` takes [Symbol]({{'/api/python/docs/api/symbol/index'|relative}}), with your Network definition, and optional node_attrs, parameters for the shape of the node in the graph,  as input and generates a computation graph.
 
 We will now try to visualize a sample Neural Network for linear matrix factorization:
 - Start Jupyter notebook server

--- a/src/pages/api/faq/why_mxnet.md
+++ b/src/pages/api/faq/why_mxnet.md
@@ -185,7 +185,7 @@ Symbolic computation is useful for several reasons. First, because we define a f
 
 ### Gluon for briding the gap between the two
 
-[MXNet Gluon]({{'/api/python'|relative_url}}) aims to bridge the gap between the imperative nature of MXNet and its symbolic capabilities and keep the advantages of both through [hybridization](http://d2l.ai/chapter_computational-performance/hybridize.html).
+[MXNet Gluon]({{'/api/python'|relative_url}}) aims to bridge the gap between the imperative nature of MXNet and its symbolic capabilities and keep the advantages of both through [hybridization](https://d2l.ai/chapter_computational-performance/hybridize.html).
 
 ## Conclusions
 Given its combination of high performance, clean code, access to a high-level API, and low-level control, _MXNet_ stands out as a unique choice among deep learning frameworks.

--- a/src/pages/api/java/docs/tutorials/mxnet_java_on_intellij.md
+++ b/src/pages/api/java/docs/tutorials/mxnet_java_on_intellij.md
@@ -115,8 +115,8 @@ Click "Import Changes" in this prompt.
 **Step 5.** Build the project:
 - To build the project, from the menu choose Build, and then choose Build Project.
 
-**Step 6.** Navigate to the App.java class in the project and paste the code in `main` method from HelloWorld.java from [Java Demo project](https://github.com/apache/incubator-mxnet/blob/java-api/scala-package/mxnet-demo/java-demo/src/main/java/mxnet/HelloWorld.java) on MXNet repository, overwriting the original hello world code.
-You can also grab the entire [Java Demo project](https://github.com/apache/incubator-mxnet/tree/java-api/scala-package/mxnet-demo/java-demo) and run it by following the instructions on the [README](https://github.com/apache/incubator-mxnet/blob/java-api/scala-package/mxnet-demo/java-demo/README.md).
+**Step 6.** Navigate to the App.java class in the project and paste the code in `main` method from HelloWorld.java from [Java Demo project](https://github.com/apache/incubator-mxnet/tree/master/scala-package/mxnet-demo/java-demo/src/main/java/mxnet/HelloWorld.java) on MXNet repository, overwriting the original hello world code.
+You can also grab the entire [Java Demo project](https://github.com/apache/incubator-mxnet/tree/master/scala-package/mxnet-demo/java-demo) and run it by following the instructions on the [README](https://github.com/apache/incubator-mxnet/blob/master/scala-package/mxnet-demo/java-demo/README.md).
 
 **Step 7.** Now run the App.java. 
 
@@ -167,6 +167,6 @@ java -cp "target/javaMXNet-1.0-SNAPSHOT.jar:target/dependency/*" mxnet.App
 ## Next Steps
 For more information about MXNet Java resources, see the following:
 
-* [Java Inference API](/api/java/index.html)
+* [Java Inference API]({{'/api/java'|relative_url}})
 * [Java Inference Examples](https://github.com/apache/incubator-mxnet/tree/master/scala-package/examples/src/main/java/org/apache/mxnetexamples/javaapi/infer)
-* [MXNet Tutorials Index](http://mxnet.io/tutorials/index.html)
+* [MXNet Tutorials Index]({{'/api'|relative_url}})

--- a/src/pages/api/java/docs/tutorials/ssd_inference.md
+++ b/src/pages/api/java/docs/tutorials/ssd_inference.md
@@ -15,7 +15,7 @@ The SSD model is trained on the Pascal VOC 2012 dataset. The network is a SSD mo
 ## Prerequisites
 
 To complete this tutorial, you need the following:
-* [MXNet Java Setup on IntelliJ IDEA](mxnet_java_on_intellij.md) (Optional)
+* [MXNet Java Setup on IntelliJ IDEA](mxnet_java_on_intellij) (Optional)
 * [wget](https://www.gnu.org/software/wget/) To download model artifacts
 * SSD Model artifacts
     * Use the following script to get the SSD Model files :
@@ -39,7 +39,7 @@ wget https://cloud.githubusercontent.com/assets/3307514/20012563/cbb41382-a27d-1
 Alternately, you can get the entire SSD Model artifacts + images in one single script from the MXNet Repository by running [get_ssd_data.sh script](https://github.com/apache/incubator-mxnet/blob/master/scala-package/examples/scripts/infer/objectdetector/get_ssd_data.sh)  
 
 ## Time to code!
-1\. Following the [MXNet Java Setup on IntelliJ IDEA](mxnet_java_on_intellij.md) tutorial, in the same project `JavaMXNet`, create a new empty class called : `ObjectDetectionTutorial.java`.
+1\. Following the [MXNet Java Setup on IntelliJ IDEA](mxnet_java_on_intellij) tutorial, in the same project `JavaMXNet`, create a new empty class called : `ObjectDetectionTutorial.java`.
 
 2\. In the `main` function of `ObjectDetectionTutorial.java` define the downloaded model path and the image data paths. This is the same path where we downloaded the model artifacts and images in a previous step.
 
@@ -189,6 +189,6 @@ The results returned by the inference call translate into the regions in the ima
 ## Next Steps
 For more information about MXNet Java resources, see the following:
 
-* [Java Inference API](/api/java/index.md)
+* [Java Inference API]({{'/api/java'|relative_url}})
 * [Java Inference Examples](https://github.com/apache/incubator-mxnet/tree/master/scala-package/examples/src/main/java/org/apache/mxnetexamples/javaapi/infer)
-* [MXNet Tutorials Index](/tutorials/index.md)
+* [MXNet Tutorials Index]({{'/api'|relative_url}})

--- a/src/pages/api/java/index.md
+++ b/src/pages/api/java/index.md
@@ -10,16 +10,16 @@ tag: java
 
 # MXNet - Java Inference API
 
-MXNet supports Java for performing inference on a trained model. The MXNet Java Inference API is an extension of the [Scala Infer API](../../api/scala/infer.html) which provides model loading and inference functionality.
+MXNet supports Java for performing inference on a trained model. The MXNet Java Inference API is an extension of the [Scala Infer API]({{'/api/scala/docs/api/#org.apache.mxnet.infer.package'|relative_url}}) which provides model loading and inference functionality.
 
 The goal of the MXNet Java package is to provide an efficient and easy to use inference API.
 The MXNet Java package makes it easy to quickly deploy an existing model into a production level Java ecosystem.
 
 ## Installation
-* [MXNet Java Inference API setup instructions](../../install/java_setup.md)
+* [MXNet Java Inference API setup instructions]({{'/get_started/java_setup'|relative_url}})
 
 ## Tutorials
-See the [tutorial page](../../tutorials/index.html#java-tutorials) for detailed tutorials and examples using the Java Inference API.
+See the [Java tutorial page]({{'/api/java/docs/tutorials'|relative_url}}) for detailed tutorials and examples using the Java Inference API.
 
 ## Java Inference API Reference
-The [Java Infer API javadocs](docs/index.html#org.apache.mxnet.infer.package) provides detailed API information.
+The [Java Infer API javadocs]({{'/api/java/docs/api/#org.apache.mxnet.infer.javaapi.package'|relative_url}}) provides detailed API information.

--- a/src/pages/api/julia/index.md
+++ b/src/pages/api/julia/index.md
@@ -19,6 +19,6 @@ computing and the state-of-art deep learning to Julia.
   and apply them to tasks such as image classification and data science challenges.
 
 ## Installation
-* [Ubuntu installation guide]({{'/get_started' | relative_url}})
+* [Ubuntu installation guide]({{'/get_started/ubuntu_setup' | relative_url}})
 * Mac / Windows guides are not available (contributions welcome!)
 

--- a/src/pages/api/perl/docs/tutorials/symbol.md
+++ b/src/pages/api/perl/docs/tutorials/symbol.md
@@ -102,7 +102,7 @@ ok 1
 
 After you have assembled a set of symbols into a computation graph, the MXNet engine can evaluate them.
 If you are training a neural network, this is typically
-handled by the high-level [AI::MXNet::Module package](module.md) and the [`fit()`] function.
+handled by the high-level [AI::MXNet::Module package](module) and the [`fit()`] function.
 
 For neural networks used in "feed-forward", "prediction", or "inference" mode (all terms for the same
 thing: running a trained network), the input arguments are the

--- a/src/pages/api/scala/docs/tutorials/char_lstm.md
+++ b/src/pages/api/scala/docs/tutorials/char_lstm.md
@@ -11,7 +11,7 @@ permalink: /api/scala/docs/tutorials/char_lstm
 This tutorial shows how to train a character-level language model with a multilayer recurrent neural network (RNN) using Scala. This model takes one text file as input and trains an RNN that learns to predict the next character in the sequence. In this tutorial, you train a multilayer LSTM (Long Short-Term Memory) network that generates relevant text using Barack Obama's speech patterns.
 
 There are many documents that explain LSTM concepts. If you aren't familiar with LSTM, refer to the following before you proceed:
-- Christopher Olah's [Understanding LSTM blog post](http://colah.github.io/posts/2015-08-Understanding-LSTMs/)
+- Christopher Olah's [Understanding LSTM blog post](https://colah.github.io/posts/2015-08-Understanding-LSTMs/)
 - [Training a LSTM char-rnn in Julia to Generate Random Sentences](http://dmlc.ml/mxnet/2015/11/15/char-lstm-in-julia.html)
 - [Bucketing in MXNet in Python](https://github.com/dmlc/mxnet-notebooks/blob/master/python/tutorials/char_lstm.ipynb)
 - [Bucketing in MXNet](http://mxnet.io/faq/bucketing.html)
@@ -62,7 +62,7 @@ In this tutorial, you will accomplish the following:
 
 ## Prerequisites
 
-To complete this tutorial, setup and run the scala interpreter by following the [instructions](https://mxnet.incubator.apache.org/install/scala_setup.html#interpreter).
+To complete this tutorial, setup and run the scala interpreter by following the [instructions]({{'/get_started/scala_setup#interpreter'|relative_url}}).
 
 ## Download the Data
 
@@ -265,7 +265,7 @@ Note: The BucketSentenceIter data iterator supports various length examples; how
 
     ```
 
-5) You can set more than 100 epochs, but for this tutorial, specify 75 epochs. Each epoch can take as long as 4 minutes on a GPU. In this tutorial, you will use the [ADAM optimizer](http://mxnet.io/api/scala/docs/index.html#org.apache.mxnet.optimizer.Adam):
+5) You can set more than 100 epochs, but for this tutorial, specify 75 epochs. Each epoch can take as long as 4 minutes on a GPU. In this tutorial, you will use the [ADAM optimizer]({{'/api/scala/docs/api/#org.apache.mxnet.optimizer.Adam'|relative_url}}):
 
     ```scala
         scala> import org.apache.mxnet._
@@ -336,7 +336,7 @@ Note: The BucketSentenceIter data iterator supports various length examples; how
 
     ```
 
-8) Now, you have implemented all the supporting infrastructures for the char-lstm model. To train the model, use the standard [MXNet high-level API](http://mxnet.io/api/scala/docs/index.html#org.apache.mxnet.FeedForward). You can train the model on a single GPU or CPU from multiple GPUs or CPUs by changing ```scala .setContext(Array(Context.gpu(0),Context.gpu(1),Context.gpu(2),Context.gpu(3)))``` to ```scala .setContext(Array(Context.gpu(0)))```:
+8) Now, you have implemented all the supporting infrastructures for the char-lstm model. To train the model, use the standard [MXNet high-level API]({{'/api/scala/docs/api/#org.apache.mxnet.FeedForward'|relative_url}}). You can train the model on a single GPU or CPU from multiple GPUs or CPUs by changing ```scala .setContext(Array(Context.gpu(0),Context.gpu(1),Context.gpu(2),Context.gpu(3)))``` to ```scala .setContext(Array(Context.gpu(0)))```:
 
     ```scala
         scala> val model = FeedForward.newBuilder(symbol)
@@ -512,6 +512,6 @@ You can see the output generated from Obama's speeches. All of the line breaks, 
 
 
 ## Next Steps
-* [Scala API](http://mxnet.io/api/scala/)
+* [Scala API]({{'/api/scala'|relative_url}})
 * [More Scala Examples](https://github.com/dmlc/mxnet/tree/master/scala-package/examples/)
-* [MXNet tutorials index](http://mxnet.io/tutorials/index.html)
+* [MXNet tutorials index]({{'/api'|relative_url}})

--- a/src/pages/api/scala/docs/tutorials/infer.md
+++ b/src/pages/api/scala/docs/tutorials/infer.md
@@ -12,9 +12,9 @@ The MXNet Scala Infer API provides you with model loading and inference function
 
 ## Prerequisites
 To use the Infer API you must first install the MXNet Scala package. Instructions for this are provided in the following variations:
-* [Tutorial for setting up a project in the IntelliJ IDE](../../tutorials/scala/mxnet_scala_on_intellij.html)
-* [Installing the MXNet Scala Package for macOS](../../install/ubuntu_setup.html#install-the-mxnet-package-for-scala)
-* [Installing the MXNet Scala for Linux](../../install/ubuntu_setup.html#install-the-mxnet-package-for-scala)
+* [Tutorial for setting up a project in the IntelliJ IDE](mxnet_scala_on_intellij)
+* [Installing the MXNet Scala Package for macOS]({{'get_started/ubuntu_setup.html#install-the-mxnet-package-for-scala'|relative_url}})
+* [Installing the MXNet Scala for Linux]({{'get_started/ubuntu_setup.html#install-the-mxnet-package-for-scala'|relative_url}})
 
 
 ## Inference
@@ -45,6 +45,6 @@ IndexedSeq[IndexedSeq[(String, Float)]] = {
 
 
 ## Related Resources
-* [Infer API Scaladocs](docs/index.html#org.apache.mxnet.infer.package)
+* [Infer API Scaladocs]({{'/api/scala/docs/api/#org.apache.mxnet.infer.package'|relative_url}})
 * [Single Shot Detector Inference Example](https://github.com/apache/incubator-mxnet/tree/master/scala-package/examples/src/main/scala/org/apache/mxnetexamples/infer/objectdetector)
 * [Image Classification Example](https://github.com/apache/incubator-mxnet/tree/master/scala-package/examples/src/main/scala/org/apache/mxnetexamples/infer/imageclassifier)

--- a/src/pages/api/scala/docs/tutorials/io.md
+++ b/src/pages/api/scala/docs/tutorials/io.md
@@ -16,7 +16,7 @@ Topics:
 * [Data Iterator Parameters](#parameters-for-data-iterator) clarifies the different usages for dataiter parameters.
 * [Create a Data Iterator](#create-a-data-iterator) introduces how to create a data iterator in MXNet for Scala.
 * [How to Get Data](#how-to-get-data) introduces the data resource and data preparation tools.
-* [IO API Reference](http://mxnet.incubator.apache.org/api/scala/docs/index.html#org.apache.mxnet.IO$) explains the IO API.
+* [IO API Reference]({{'/api/scala/docs/api/#org.apache.mxnet.io.package'|relative_url}}) explains the IO API.
 
 
 ## Data Iterator Parameters
@@ -169,5 +169,5 @@ For example, if you have four labels for a single image, you can use the followi
      ```
 
 ## Next Steps
-* [NDArray API](ndarray.md) for vector/matrix/tensor operations
-* [KVStore API](kvstore.md) for multi-GPU and multi-host distributed training
+* [NDArray API](ndarray) for vector/matrix/tensor operations
+* [KVStore API](kvstore) for multi-GPU and multi-host distributed training

--- a/src/pages/api/scala/docs/tutorials/kvstore.md
+++ b/src/pages/api/scala/docs/tutorials/kvstore.md
@@ -11,7 +11,7 @@ tag: scala
 Topics:
 * [Basic Push and Pull](#basic-push-and-pull)
 * [List Key-Value Pairs](#list-key-value-pairs)
-* [API Reference](http://mxnet.incubator.apache.org/api/scala/docs/index.html#org.apache.mxnet.KVStore)
+* [API Reference]({{'/api/scala/docs/api/#org.apache.mxnet.KVStore'|relative_url}})
 
 
 ## Basic Push and Pull

--- a/src/pages/api/scala/docs/tutorials/mnist.md
+++ b/src/pages/api/scala/docs/tutorials/mnist.md
@@ -15,7 +15,7 @@ Let's train a 3-layer network (i.e multilayer perceptron network) on the MNIST d
 ## Prerequisites
 To complete this tutorial, we need:
 
-- to compile the latest MXNet version. See the MXNet installation instructions for your operating system in [Setup and Installation](http://mxnet.io/install/index.html).
+- to compile the latest MXNet version. See the MXNet installation instructions for your operating system in [Setup and Installation]({{'/get_started'|relative_url}}).
 - to compile the Scala API. See Scala API build instructions in [Build](https://github.com/dmlc/mxnet/tree/master/scala-package).
 
 ## Define the Network
@@ -120,6 +120,6 @@ println(s"Final accuracy = $acc")
 Check out more MXNet Scala examples below.
 
 ## Next Steps
-* [Scala API](http://mxnet.io/api/scala/)
+* [Scala API]({{'/api/scala'|relative_url}})
 * [More Scala Examples](https://github.com/dmlc/mxnet/tree/master/scala-package/examples/)
-* [MXNet tutorials index](http://mxnet.io/tutorials/index.html)
+* [MXNet tutorials index]({{'/api'|relative_url}})

--- a/src/pages/api/scala/docs/tutorials/model.md
+++ b/src/pages/api/scala/docs/tutorials/model.md
@@ -9,16 +9,16 @@ tag: scala
 # MXNet Scala Model API
 
 The model API provides a simplified way to train neural networks using common best practices.
-It's a thin wrapper built on top of the [ndarray](ndarray.md) and [symbolic](symbol.md)
+It's a thin wrapper built on top of the [ndarray](ndarray) and [symbolic](symbol)
 modules that make neural network training easy.
 
 Topics:
 
-* [Train a Model](#train-a-model)
+* [Train the Model](#train-the-model)
 * [Save the Model](#save-the-model)
 * [Periodic Checkpoint](#periodic-checkpointing)
 * [Multiple Devices](#use-multiple-devices)
-* [Model API Reference](#http://mxnet.incubator.apache.org/api/scala/docs/index.html#org.apache.mxnet.Model)
+* [Model API Reference]({{'/api/scala/docs/api/#org.apache.mxnet.Model'|relative_url}})
 
 ## Train the Model
 
@@ -56,7 +56,7 @@ You can also use the `scikit-learn-style` construct and `fit` function to create
 
   model.fit(trainData = train)
 ```
-For more information, see [API Reference](http://mxnet.incubator.apache.org/api/scala/docs/index.html).
+For more information, see [API Reference]({{'/api/scala/docs/api/#package'|relative_url}}).
 
 ## Save the Model
 
@@ -120,7 +120,7 @@ Set ```ctx``` to the list of devices that you want to train on. You can create a
 Training occurs in parallel on the GPUs that you specify.
 
 ## Next Steps
-* See [Symbolic API](symbol.md) for operations on NDArrays that assemble neural networks from layers.
-* See [IO Data Loading API](io.md) for parsing and loading data.
-* See [NDArray API](ndarray.md) for vector/matrix/tensor operations.
-* See [KVStore API](kvstore.md) for multi-GPU and multi-host distributed training.
+* See [Symbolic API](symbol) for operations on NDArrays that assemble neural networks from layers.
+* See [IO Data Loading API](io) for parsing and loading data.
+* See [NDArray API](ndarray) for vector/matrix/tensor operations.
+* See [KVStore API](kvstore) for multi-GPU and multi-host distributed training.

--- a/src/pages/api/scala/docs/tutorials/module.md
+++ b/src/pages/api/scala/docs/tutorials/module.md
@@ -56,13 +56,13 @@ Modules provide high-level APIs for training, predicting, and evaluating. To fit
     .setOptimizer(new SGD(learningRate = 0.1f, momentum = 0.9f, wd = 0.0001f)))
 ```
 
-The interface is very similar to the old `FeedForward` class. You can pass in batch-end callbacks using `setBatchEndCallback` and epoch-end callbacks using `setEpochEndCallback`. You can also set parameters using methods like `setOptimizer` and `setEvalMetric`. To learn more about the `FitParams()`, see the [API page](http://mxnet.io/api/scala/docs/index.html#org.apache.mxnet.module.FitParams). To predict with a module, call `predict()` with a `DataIter`:
+The interface is very similar to the old `FeedForward` class. You can pass in batch-end callbacks using `setBatchEndCallback` and epoch-end callbacks using `setEpochEndCallback`. You can also set parameters using methods like `setOptimizer` and `setEvalMetric`. To learn more about the `FitParams()`, see the [API page]({{'/api/scala/docs/api/#org.apache.mxnet.module.FitParams'|relative_url}}). To predict with a module, call `predict()` with a `DataIter`:
 
 ```scala
     mod.predict(val_dataiter)
 ```
 
-The module collects and returns all of the prediction results. For more details about the format of the return values, see the documentation for the [`predict()` function](http://mxnet.incubator.apache.org/api/scala/docs/index.html#org.apache.mxnet.module.BaseModule).
+The module collects and returns all of the prediction results. For more details about the format of the return values, see the documentation for the [`predict()` function]({{'/api/scala/docs/api/#org.apache.mxnet.module.BaseModule'|relative_url}}).
 
 When prediction results might be too large to fit in memory, use the `predictEveryBatch` API:
 
@@ -139,8 +139,8 @@ To resume training from a saved checkpoint, instead of calling `setParams()`, di
 Create an object of the `FitParams()` class, and then use it to call the `setBeginEpoch()` method to pass `beginEpoch` so that `fit()` knows to resume from a saved epoch.
 
 ## Next Steps
-* See [Model API](model.md) for an alternative simple high-level interface for training neural networks.
-* See [Symbolic API](symbol.md) for operations on NDArrays that assemble neural networks from layers.
-* See [IO Data Loading API](io.md) for parsing and loading data.
-* See [NDArray API](ndarray.md) for vector/matrix/tensor operations.
-* See [KVStore API](kvstore.md) for multi-GPU and multi-host distributed training.
+* See [Model API](model) for an alternative simple high-level interface for training neural networks.
+* See [Symbolic API](symbol) for operations on NDArrays that assemble neural networks from layers.
+* See [IO Data Loading API](io) for parsing and loading data.
+* See [NDArray API](ndarray) for vector/matrix/tensor operations.
+* See [KVStore API](kvstore) for multi-GPU and multi-host distributed training.

--- a/src/pages/api/scala/docs/tutorials/mxnet_scala_on_intellij.md
+++ b/src/pages/api/scala/docs/tutorials/mxnet_scala_on_intellij.md
@@ -388,7 +388,7 @@ This can be resolved be installing OpenCV.
 
 ### Using MXNet from source
 
-If you chose to "Build from Source" when following the [install instructions](https://mxnet.incubator.apache.org/install/index.html) (or the detailed [build from source instructions](https://mxnet.incubator.apache.org/install/build_from_source.html#installing-mxnet-language-bindings)), you can use your custom build instead of the build from maven.  Use your build by editing the `pom.xml` file and replacing the `org.apache.mxnet` dependency with the following:
+If you chose to "Build from Source" when following the [install instructions]({{'/get_started'|relative_url}}) (or the detailed [build from source instructions]({{'/get_started/build_from_source.html#installing-mxnet-language-bindings'|relative_url}})), you can use your custom build instead of the build from maven.  Use your build by editing the `pom.xml` file and replacing the `org.apache.mxnet` dependency with the following:
 
 ```
       <groupId>org.apache.mxnet</groupId>
@@ -434,7 +434,7 @@ The build generates a new jar file in the `target` folder called `scalaInference
 ## Next Steps
 For more information about MXNet Scala resources, see the following:
 
-* [Scala API](http://mxnet.io/api/scala/)
+* [Scala API]({{'/api/scala'|relative_url}})
 * [Scala Inference API](https://mxnet.incubator.apache.org/api/scala/infer.html)
 * [Scala Examples](https://github.com/apache/incubator-mxnet/tree/master/scala-package/examples/)
-* [MXNet Tutorials Index](http://mxnet.io/tutorials/index.html)
+* [MXNet Tutorials Index]({{'/api'|relative_url}})

--- a/src/pages/api/scala/docs/tutorials/ndarray.md
+++ b/src/pages/api/scala/docs/tutorials/ndarray.md
@@ -15,7 +15,7 @@ Topics:
 
 * [Create NDArray](#create-ndarray)
 * [NDArray Operations](#ndarray-operations)
-* [NDArray API Reference](http://mxnet.incubator.apache.org/api/scala/docs/index.html#org.apache.mxnet.NDArray)
+* [NDArray API Reference]({{'/api/scala/docs/api/#org.apache.mxnet.NDArray'|relative_url}})
 
 ## Create NDArray
 
@@ -162,4 +162,4 @@ val z = x + cpu_y
 ```
 
 ## Next Steps
-* See [KVStore API](kvstore.md) for multi-GPU and multi-host distributed training.
+* See [KVStore API](kvstore) for multi-GPU and multi-host distributed training.

--- a/src/pages/api/scala/docs/tutorials/symbol.md
+++ b/src/pages/api/scala/docs/tutorials/symbol.md
@@ -10,15 +10,15 @@ tag: scala
 
 Topics:
 
-* [How to Compose Symbols](#overloaded-operators) introduces operator overloading of symbols.
+* [How to Compose Symbols](#how-to-compose-symbols) introduces operator overloading of symbols.
 * [Symbol Attributes](#symbol-attributes) describes how to attach attributes to symbols.
 * [Serialization](#serialization) explains how to save and load symbols.
 * [Executing Symbols](#executing-symbols) explains how to evaluate the symbols with data.
-* [Execution API Reference](http://mxnet.incubator.apache.org/api/scala/docs/index.html#org.apache.mxnet.Executor) documents the execution APIs.
+* [Execution API Reference]({{'/api/scala/docs/api/#org.apache.mxnet.Executor'|relative_url}}) documents the execution APIs.
 * [Multiple Outputs](#multiple-outputs) explains how to configure multiple outputs.
-* [Symbol Creation API Reference](http://mxnet.incubator.apache.org/api/scala/docs/index.html#org.apache.mxnet.Symbol) documents functions.
+* [Symbol Creation API Reference]({{'/api/scala/docs/api/#org.apache.mxnet.Symbol'|relative_url}}) documents functions.
 
-We also highly encourage you to read [Symbolic Configuration and Execution in Pictures](symbol_in_pictures.md).
+We also highly encourage you to read [Symbolic Configuration and Execution in Pictures](symbol_in_pictures).
 
 ## How to Compose Symbols
 
@@ -86,7 +86,7 @@ To attach attributes, you can use ```AttrScope```. ```AttrScope``` automatically
 There are two ways to save and load the symbols. You can use the `mxnet.Symbol.save` and `mxnet.Symbol.load` functions to serialize the ```Symbol``` objects.
 The advantage of using `save` and `load` functions is that it is language agnostic and cloud friendly.
 The symbol is saved in JSON format. You can also get a JSON string directly using `mxnet.Symbol.toJson`.
-Refer to [API documentation](http://mxnet.incubator.apache.org/api/scala/docs/index.html#org.apache.mxnet.Symbol) for more details.
+Refer to [API documentation]({{'/api/scala/docs/api/#org.apache.mxnet.Symbol'|relative_url}}) for more details.
 
 The following example shows how to save a symbol to an S3 bucket, load it back, and compare two symbols using a JSON string.
 
@@ -105,7 +105,7 @@ The following example shows how to save a symbol to an S3 bucket, load it back, 
 
 After you have assembled a set of symbols into a computation graph, the MXNet engine can evaluate them.
 If you are training a neural network, this is typically
-handled by the high-level [Model class](model.md) and the [`fit()`] function.
+handled by the high-level [Model class](model) and the [`fit()`] function.
 
 For neural networks used in "feed-forward", "prediction", or "inference" mode (all terms for the same
 thing: running a trained network), the input arguments are the
@@ -134,6 +134,6 @@ After you get the ```group```, you can bind on ```group``` instead.
 The resulting executor will have two outputs, one for fc1_output and one for softmax_output.
 
 ## Next Steps
-* See [IO Data Loading API](io.md) for parsing and loading data.
-* See [NDArray API](ndarray.md) for vector/matrix/tensor operations.
-* See [KVStore API](kvstore.md) for multi-GPU and multi-host distributed training.
+* See [IO Data Loading API](io) for parsing and loading data.
+* See [NDArray API](ndarray) for vector/matrix/tensor operations.
+* See [KVStore API](kvstore) for multi-GPU and multi-host distributed training.

--- a/src/pages/api/scala/docs/tutorials/symbol_in_pictures.md
+++ b/src/pages/api/scala/docs/tutorials/symbol_in_pictures.md
@@ -9,7 +9,7 @@ tag: scala
 # Symbolic Configuration and Execution in Pictures
 
 This topic explains symbolic construction and execution in pictures.
-We recommend that you also read [Symbolic API](symbol.md).
+We recommend that you also read [Symbolic API](symbol).
 
 ## Compose Symbols
 
@@ -81,4 +81,4 @@ Auxiliary states are just like arguments, except that you can't take the gradien
 
 ## Next Steps
 
-See [Symbolic API](symbol.md) and [Python Documentation](index.md).
+See [Symbolic API](symbol) and [Python Documentation]({{'/api/python'|relative_url}}).

--- a/src/pages/get_started/build_from_source.md
+++ b/src/pages/get_started/build_from_source.md
@@ -11,7 +11,7 @@ permalink: /get_started/build_from_source
 
 This document explains how to build MXNet from source code.
 
-**For Java/Scala/Clojure, please follow [this guide instead](./scala_setup.md)**
+**For Java/Scala/Clojure, please follow [this guide instead](scala_setup)**
 
 ## Overview
 
@@ -34,14 +34,14 @@ Building from source follows this general two-step flow of building the shared l
             * [non-Intel CPUs](#recommended-for-Systems-with-non-Intel-CPUs)
 2. [Install the language API binding(s)](#installing-mxnet-language-bindings) you would like to use for MXNet.
 MXNet's newest and most popular API is Gluon. Gluon is built into the Python binding. If Python isn't your preference, you still have more options. MXNet supports several other language APIs:
-    - [Python (includes Gluon)](../api/python/index.md)
-    - [C++](../api/cpp/index.md)
-    - [Clojure](../api/clojure/index.md)
-    - [Java](../api/java/index.md)
-    - [Julia](../api/julia/index.md)
-    - [Perl](../api/perl/index.md)
-    - [R](../api/r/index.md)
-    - [Scala](../api/scala/index.md)
+    - [Python (includes Gluon)]({{'/api/python/index'|relative_url}})
+    - [C++]({{'/api/cpp'|relative_url}})
+    - [Clojure]({{'/api/clojure'|relative_url}})
+    - [Java]({{'/api/java'|relative_url}})
+    - [Julia]({{'/api/julia'|relative_url}})
+    - [Perl]({{'/api/perl'|relative_url}})
+    - [R]({{'/api/r'|relative_url}})
+    - [Scala]({{'/api/scala'|relative_url}})
 
 <hr>
 
@@ -50,11 +50,11 @@ MXNet's newest and most popular API is Gluon. Gluon is built into the Python bin
 Detailed instructions are provided per operating system. Each of these guides also covers how to install the specific [Language Bindings](#installing-mxnet-language-bindings) you require.
 You may jump to those, but it is recommended that you continue reading to understand more general "build from source" options.
 
-* [Amazon Linux / CentOS / RHEL](centos_setup.md)
-* [macOS](osx_setup.md)
-* [Devices](https://mxnet.incubator.apache.org/versions/master/install/index.html?platform=Devices&language=Python&processor=CPU)
-* [Ubuntu](ubuntu_setup.md)
-* [Windows](windows_setup.md)
+* [Amazon Linux / CentOS / RHEL](centos_setup)
+* [macOS](osx_setup)
+* [Devices](index.html?&platform=devices&language=python&environ=pip&processor=cpu)
+* [Ubuntu](ubuntu_setup)
+* [Windows](windows_setup)
 
 
 <hr>
@@ -85,7 +85,7 @@ MXNet supports multiple mathematical backends for computations on the CPU:
 * [ATLAS](http://math-atlas.sourceforge.net/)
 * [MKL](https://software.intel.com/en-us/intel-mkl) (MKL, MKLML)
 * [MKL-DNN](https://github.com/intel/mkl-dnn)
-* [OpenBLAS](http://www.openblas.net/)
+* [OpenBLAS](https://www.openblas.net/)
 
 The default order of choice for the libraries if found follows the path from the most
 (recommended) to less performant backends.
@@ -298,13 +298,13 @@ ninja -v
 ## Installing MXNet Language Bindings
 After building MXNet's shared library, you can install other language bindings.
 
-**NOTE:** The C++ API binding must be built when you build MXNet from source. See [Build MXNet with C++](#build-mxnet-with-c++).
+**NOTE:** The C++ API binding must be built when you build MXNet from source. See [Build MXNet with C++]({{'/api/cpp'|relative_url}}).
 
 The following table provides links to each language binding by operating system:
-| | [Ubuntu](ubuntu_setup.html) | [macOS](osx_setup.html) | [Windows](windows_setup.html) |
+| | [Ubuntu](ubuntu_setup) | [macOS](osx_setup) | [Windows](windows_setup) |
 | --- | ----  | --- | ------- |
-| Python | [Ubuntu guide](ubuntu_setup.html#install-mxnet-for-python) | [OSX guide](osx_setup.html) | [Windows guide](windows_setup.html#install-mxnet-for-python) |
-| C++ | [C++ guide](c_plus_plus.html) | [C++ guide](c_plus_plus.html) | [C++ guide](c_plus_plus.html) |
+| Python | [Ubuntu guide](ubuntu_setup.html#install-mxnet-for-python) | [OSX guide](osx_setup) | [Windows guide](windows_setup.html#install-mxnet-for-python) |
+| C++ | [C++ guide](cpp_setup) | [C++ guide](cpp_setup) | [C++ guide](cpp_setup) |
 | Clojure | [Clojure guide](https://github.com/apache/incubator-mxnet/tree/master/contrib/clojure-package) | [Clojure guide](https://github.com/apache/incubator-mxnet/tree/master/contrib/clojure-package) | n/a |
 | Julia | [Ubuntu guide](ubuntu_setup.html#install-the-mxnet-package-for-julia) | [OSX guide](osx_setup.html#install-the-mxnet-package-for-julia) | [Windows guide](windows_setup.html#install-the-mxnet-package-for-julia) |
 | Perl | [Ubuntu guide](ubuntu_setup.html#install-the-mxnet-package-for-perl) | [OSX guide](osx_setup.html#install-the-mxnet-package-for-perl) | n/a |

--- a/src/pages/get_started/c_plus_plus.md
+++ b/src/pages/get_started/c_plus_plus.md
@@ -10,7 +10,7 @@ permalink: /get_started/cpp_setup
 ## Build the C++ package
 The C++ package has the same prerequisites as the MXNet library.
 
-To enable C++ package, just add `USE_CPP_PACKAGE=1` in the [build from source](build_from_source.md) options when building the MXNet shared library.
+To enable C++ package, just add `USE_CPP_PACKAGE=1` in the [build from source](build_from_source) options when building the MXNet shared library.
 
 For example to build MXNet with GPU support and the C++ package, OpenCV, and OpenBLAS, from the project root you would run:
 
@@ -32,7 +32,7 @@ You can find C++ code examples in the `cpp-package/example` folder of the MXNet 
 
 ## Tutorials
 
-* [MXNet C++ API Basics](../api/cpp/docs/tutorials/basics)
+* [MXNet C++ API Basics]({{'/api/cpp/docs/tutorials/basics'|relative_url}})
 
 ## Related Topics
 

--- a/src/pages/get_started/java_setup.md
+++ b/src/pages/get_started/java_setup.md
@@ -10,7 +10,7 @@ permalink: /get_started/java_setup
 
 The following instructions are provided for macOS and Ubuntu. Windows is not yet available.
 
-**Note:** If you use IntelliJ or a similar IDE, you may want to follow the [MXNet-Java on IntelliJ tutorial](../tutorials/java/mxnet_java_on_intellij.md) instead of these instructions.
+**Note:** If you use IntelliJ or a similar IDE, you may want to follow the [MXNet-Java on IntelliJ tutorial]({{'/api/java/docs/tutorials/mxnet_java_on_intellij'|relative_url}}) instead of these instructions.
 
 <hr>
 
@@ -106,7 +106,7 @@ This will install both the Java Inference API and the required MXNet-Scala packa
 
 ## Documentation
 
-Javadocs are generated as part of the docs build pipeline. You can find them published in the [Java API](../api/java/index.md) section of the website or by going to the [scaladocs output](https://mxnet.incubator.apache.org/api/scala/docs/index.html#org.apache.mxnet.package) directly.
+Javadocs are generated as part of the docs build pipeline. You can find them published in the [Java API]({{'/api/java'|relative_url}}) section of the website or by going to the [scaladocs output]({{'/api/scala/docs/api/#org.apache.mxnet.package'|relative_url}}) directly.
 
 To build the docs yourself, follow the [developer build docs instructions](https://github.com/apache/incubator-mxnet/tree/master/docs/build_version_doc#developer-instructions).
 
@@ -114,6 +114,6 @@ To build the docs yourself, follow the [developer build docs instructions](https
 
 ## Resources
 
-* [Java API](../api/java/)
-* [javadocs](https://mxnet.incubator.apache.org/api/scala/docs/index.html#org.apache.mxnet.package)
-* [MXNet-Java Tutorials](../tutorials/java/)
+* [Java API]({{'/api/java'|relative_url}})
+* [javadocs]({{'/api/scala/docs/api/#org.apache.mxnet.package'|relative_url}})
+* [MXNet-Java Tutorials]({{'/api/java/docs/tutorials'|relative_urls}})

--- a/src/pages/get_started/osx_setup.md
+++ b/src/pages/get_started/osx_setup.md
@@ -86,7 +86,7 @@ Install the dependencies, required for MXNet, with the following commands:
 ```
 
 ### Build MXNet Shared Library
-After you have installed the dependencies, pull the MXNet source code from Git and build MXNet to produce an MXNet library called ```libmxnet.so```. You can clone the repository as described in the following code block, or you may try the [download links](download.md) for your desired MXNet version.
+After you have installed the dependencies, pull the MXNet source code from Git and build MXNet to produce an MXNet library called ```libmxnet.so```. You can clone the repository as described in the following code block, or you may try the [download links](download) for your desired MXNet version.
 
 The file called ```osx.mk``` has the configuration required for building MXNet on OS X. First copy ```make/osx.mk``` into ```config.mk```, which is used by the ```make``` command:
 
@@ -207,16 +207,16 @@ You might want to add this command to your ```~/.bashrc``` file. If you do, you 
 	Pkg.add("MXNet")
 ```
 
-For more details about installing and using MXNet with Julia, see the [MXNet Julia documentation](http://dmlc.ml/MXNet.jl/latest/user-guide/install/).
+For more details about installing and using MXNet with Julia, see the [MXNet Julia documentation]({{'/api/julia'|relative_url}}).
 
 
 ## Install the MXNet Package for Scala
 
 To use the MXNet-Scala package, you can acquire the Maven package as a dependency.
 
-Further information is in the [MXNet-Scala Setup Instructions](./scala_setup.md).
+Further information is in the [MXNet-Scala Setup Instructions](scala_setup).
 
-If you use IntelliJ or a similar IDE, you may want to follow the [MXNet-Scala on IntelliJ tutorial](../tutorials/scala/mxnet_scala_on_intellij.md) instead.
+If you use IntelliJ or a similar IDE, you may want to follow the [MXNet-Scala on IntelliJ tutorial]({{'/api/scala/docs/tutorials/mxnet_scala_on_intellij'|relative_url}}) instead.
 
 
 ## Install the MXNet Package for Perl
@@ -254,6 +254,6 @@ After you build the shared library, run the following command from the MXNet sou
 
 ## Next Steps
 
-* [Tutorials](../tutorials/index.md)
-* [How To](../faq/index.md)
-* [Architecture](../architecture/index.md)
+* [Tutorials]({{'/api'|relative_url}})
+* [How To]({{'/api/faq/add_op_in_backend'|relative_url}})
+* [Architecture]({{'/api/architecture/overview'|relative_url}})

--- a/src/pages/get_started/scala_setup.md
+++ b/src/pages/get_started/scala_setup.md
@@ -11,7 +11,7 @@ permalink: /get_started/scala_setup
 
 The following instructions are provided for macOS and Ubuntu. Windows is not yet available.
 
-**Note:** If you use IntelliJ or a similar IDE, you may want to follow the [MXNet-Scala on IntelliJ tutorial](../tutorials/scala/mxnet_scala_on_intellij.md) instead of these instructions.
+**Note:** If you use IntelliJ or a similar IDE, you may want to follow the [MXNet-Scala on IntelliJ tutorial]({{'/api/scala/docs/tutorials/mxnet_scala_on_intellij'|relative_url}}) instead of these instructions.
 **Note:** Currently, we only support scala 2.11
 
 <hr>
@@ -136,7 +136,7 @@ If you receive a "NumberFormatException" when running the interpreter, run `expo
 
 ## Documentation
 
-Scaladocs are generated as part of the docs build pipeline. You can find them published in the [Scala API](../api/scala/index.md) section of the website or by going to the [scaladocs output](https://mxnet.incubator.apache.org/api/scala/docs/index.html#org.apache.mxnet.package) directly.
+Scaladocs are generated as part of the docs build pipeline. You can find them published in the [Scala API]({{'/api/scala'|relative_url}}) section of the website or by going to the [scaladocs output]({{'/api/scala/docs/api/#org.apache.mxnet.package'|relative_url}}) directly.
 
 To build the docs yourself, follow the [developer build docs instructions](https://github.com/apache/incubator-mxnet/tree/master/docs/build_version_doc#developer-instructions).
 
@@ -144,6 +144,6 @@ To build the docs yourself, follow the [developer build docs instructions](https
 
 ## Resources
 
-* [Scala API](../api/scala/)
-* [scaladocs](https://mxnet.incubator.apache.org/api/scala/docs/index.html#org.apache.mxnet.package)
-* [MXNet-Scala Tutorials](../tutorials/scala/)
+* [Scala API]({{'/api/scala'|relative_url}})
+* [scaladocs]({{'/api/scala/docs/api/#org.apache.mxnet.package'|relative_url}})
+* [MXNet-Scala Tutorials]({{'/api/scala/docs/tutorials'|relative_url}})

--- a/src/pages/get_started/ubuntu_setup.md
+++ b/src/pages/get_started/ubuntu_setup.md
@@ -289,7 +289,7 @@ sudo pip install graphviz==0.8.4 \
 
 ### Install the MXNet Package for C++
 
-Refer to the [C++ Package setup guide](c_plus_plus).
+Refer to the [C++ Package setup guide](cpp_setup).
 <hr>
 
 
@@ -387,7 +387,7 @@ julia --color=yes --project=./ -e \
 	   Pkg.develop(PackageSpec(name="MXNet", path = joinpath(ENV["MXNET_HOME"], "julia")))'
 ```
 
-For more details about installing and using MXNet with Julia, see the [MXNet Julia documentation](../api/julia/site/).
+For more details about installing and using MXNet with Julia, see the [MXNet Julia documentation]({{'/api/julia'|relative_url}}).
 <hr>
 
 
@@ -454,14 +454,14 @@ $ sudo apt-get install -y build-essential git
 
 **Step 2** Install OpenBLAS.
 
-*MXNet* uses [BLAS](https://en.wikipedia.org/wiki/Basic_Linear_Algebra_Subprograms) and [LAPACK](https://en.wikipedia.org/wiki/LAPACK) libraries for accelerated numerical computations on CPU machine. There are several flavors of BLAS/LAPACK libraries - [OpenBLAS](http://www.openblas.net/), [ATLAS](http://math-atlas.sourceforge.net/) and [MKL](https://software.intel.com/en-us/intel-mkl). In this step we install OpenBLAS. You can choose to install ATLAS or MKL.
+*MXNet* uses [BLAS](https://en.wikipedia.org/wiki/Basic_Linear_Algebra_Subprograms) and [LAPACK](https://en.wikipedia.org/wiki/LAPACK) libraries for accelerated numerical computations on CPU machine. There are several flavors of BLAS/LAPACK libraries - [OpenBLAS](https://www.openblas.net/), [ATLAS](http://math-atlas.sourceforge.net/) and [MKL](https://software.intel.com/en-us/intel-mkl). In this step we install OpenBLAS. You can choose to install ATLAS or MKL.
 ```bash
 $ sudo apt-get install -y libopenblas-dev liblapack-dev
 ```
 
 **Step 3** Install OpenCV.
 
-*MXNet* uses [OpenCV](http://opencv.org/) for efficient image loading and augmentation operations.
+*MXNet* uses [OpenCV](https://opencv.org/) for efficient image loading and augmentation operations.
 ```bash
 $ sudo apt-get install -y libopencv-dev
 ```
@@ -519,7 +519,7 @@ To use the MXNet-Scala package, you can acquire the Maven package as a dependenc
 
 Further information is in the [MXNet-Scala Setup Instructions](scala_setup).
 
-If you use IntelliJ or a similar IDE, you may want to follow the [MXNet-Scala on IntelliJ tutorial](../api/scala/docs/tutorials/mxnet_scala_on_intellij) instead.
+If you use IntelliJ or a similar IDE, you may want to follow the [MXNet-Scala on IntelliJ tutorial]({{'/api/scala/docs/tutorials/mxnet_scala_on_intellij'|relative_url}}) instead.
 <hr>
 
 ### Install the MXNet Package for Java
@@ -528,18 +528,18 @@ To use the MXNet-Java package, you can acquire the Maven package as a dependency
 
 Further information is in the [MXNet-Java Setup Instructions](java_setup).
 
-If you use IntelliJ or a similar IDE, you may want to follow the [MXNet-Java on IntelliJ tutorial](../api/java/docs/tutorials/mxnet_java_on_intellij) instead.
+If you use IntelliJ or a similar IDE, you may want to follow the [MXNet-Java on IntelliJ tutorial]({{'/api/java/docs/tutorials/mxnet_java_on_intellij'|relative_url}}) instead.
 <hr>
 
 ## Contributions
 
-You are more than welcome to contribute easy installation scripts for other operating systems and programming languages. See the [community contributions page](../community/contribute) for further information.
+You are more than welcome to contribute easy installation scripts for other operating systems and programming languages. See the [community contributions page]({{'/community/contribute'|relative_url}}) for further information.
 
 ## Next Steps
 
-* [Tutorials](../api/python/docs/tutorials)
-* [How To](../api)
-* [Architecture](../api)
+* [Tutorials]({{'/api'|relative_url}})
+* [How To]({{'/api/faq/add_op_in_backend'|relative_url}})
+* [Architecture]({{'/api/architecture/overview'|relative_url}})
 
 
 <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.1.0/css/all.css" integrity="sha384-lKuwvrZot6UHsBSfcMvOkWwlCMgc0TaWr+30HWe3a4ltaBwTZhyTEggF5tJv8tbt" crossorigin="anonymous">

--- a/src/pages/get_started/windows_setup.md
+++ b/src/pages/get_started/windows_setup.md
@@ -14,7 +14,7 @@ The following describes how to install with pip for computers with CPUs, Intel C
 - [Install MXNet with Python](#install-mxnet-with-python)
     - [Install with CPUs](#install-with-cpus)
     - [Install with Intel CPUs](#install-with-intel-cpus)
-    - [Install with GPUs](#install-with-gpus)
+    - [Install with NVIDIA GPUs](#install-with-nvidia-gpus)
     - [Notes on the Python Packages](#notes-on-the-python-packages)
 - [Build from Source](#build-from-source)
 - Install MXNet with a Programming Language API
@@ -58,7 +58,7 @@ Install MXNet with CPU support with Python:
 pip install mxnet
 ```
 
-Now [validate your MXNet installation with Python](validate_mxnet.md).
+Now [validate your MXNet installation with Python](validate_mxnet).
 
 ### Install with Intel CPUs
 
@@ -72,7 +72,7 @@ The following steps will setup MXNet with MKL. MKL-DNN can be enabled only when 
 pip install mxnet-mkl
 ```
 
-Now [validate your MXNet installation with Python](validate_mxnet.md).
+Now [validate your MXNet installation with Python](validate_mxnet).
 
 ### Install with NVIDIA GPUs
 
@@ -92,7 +92,7 @@ The following steps will setup MXNet with CUDA. cuDNN can be enabled only when b
 pip install mxnet-cu92
 ```
 
-Once you have installed a version of MXNet, [validate your MXNet installation with Python](validate_mxnet.md).
+Once you have installed a version of MXNet, [validate your MXNet installation with Python](validate_mxnet).
 
 #### Install with CUDA and MKL Support
 
@@ -109,7 +109,7 @@ The following steps will setup MXNet with CUDA and MKL.
 pip install mxnet-cu92mkl
 ```
 
-Once you have installed a version of MXNet, [validate your MXNet installation with Python](validate_mxnet.md).
+Once you have installed a version of MXNet, [validate your MXNet installation with Python](validate_mxnet).
 
 ### Notes on the Python Packages
 To get further enhancements for deep neural networks, you may want to enable MKL-DNN and/or cuDNN. Each of these require you to [build from source](#build-from-source) and to enable the build flags for each.
@@ -121,7 +121,7 @@ Check the chart below for other options or refer to [PyPI for other MXNet pip pa
 
 ## Build from Source
 
-**IMPORTANT: It is recommended that you review the [build from source guide](build_from_source.md) first.** It describes many of the build options that come with MXNet in more detail. You may decide to install additional dependencies and modify your build flags after reviewing this material.
+**IMPORTANT: It is recommended that you review the [build from source guide](build_from_source) first.** It describes many of the build options that come with MXNet in more detail. You may decide to install additional dependencies and modify your build flags after reviewing this material.
 
 We provide two primary options to build and install MXNet yourself using [Microsoft Visual Studio 2017](https://www.visualstudio.com/downloads/) or [Microsoft Visual Studio 2015](https://www.visualstudio.com/vs/older-downloads/).
 
@@ -211,7 +211,7 @@ Next, we install ```graphviz``` library that we use for visualizing network grap
 
 We have installed MXNet core library. Next, we will install MXNet interface package for programming language of your choice:
 - [Python](#install-the-mxnet-package-for-python)
-- [R](#install-mxnet-package-for-r)
+- [R](#install-the-mxnet-package-for-r)
 - [Julia](#install-the-mxnet-package-for-julia)
 - **Scala** is not yet available for Windows
 
@@ -245,7 +245,7 @@ opencv_world341.dll (in OpenCV folder you download)
 
 Done! We have installed MXNet with Python interface.
 
-You can continue with using MXNet-Python, or if you want to try a different language API for MXNet, keep reading. Otherwise, jump ahead to [next steps](#next-steps).
+You can continue with using MXNet-Python, or if you want to try a different language API for MXNet, keep reading.
 
 ## Install the MXNet Package for R
 MXNet for R is available for both CPUs and GPUs.
@@ -466,7 +466,7 @@ You might want to add this command to your ```~/.bashrc``` file. If you do, you 
 Pkg.add("MXNet")
 ```
 
-For more details about installing and using MXNet with Julia, see the [MXNet Julia documentation](/api/julia/site/).
+For more details about installing and using MXNet with Julia, see the [MXNet Julia documentation]({{'/api/julia'|relative_url}}).
 
 
 ## Installing the MXNet Package for Scala


### PR DESCRIPTION
Updated links from mxnet.incubator.apache.org to the new site. Also updated hardcoded links to relative links and updated to https where available.

